### PR TITLE
Fixed wrongly retrieved hash.

### DIFF
--- a/bucket/notepad4.json
+++ b/bucket/notepad4.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/zufuliu/notepad4/releases/download/v25.09r5812/Notepad4_HD_i18n_AVX2_v25.09r5812.zip",
-            "hash": "559e139dc23ae79bfd1f12d7548c12f2f66cdb95147e86f6ebfa98b53d87bd9f"
+            "hash": "48217a0398cdb39b083e44e438b08b02396072eb1f4e8475b062e620e94908d7"
         },
         "32bit": {
             "url": "https://github.com/zufuliu/notepad4/releases/download/v25.09r5812/Notepad4_i18n_Win32_v25.09r5812.zip",


### PR DESCRIPTION
Because the installation package was changed after new release published, scoop Github action did not recorded that.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
