### PR TITLE
1Password: Fixed source after portable package deprecation.

### DIFF
--- a/bucket/1password.json
+++ b/bucket/1password.json
@@ -1,5 +1,5 @@
 {
-    "version": "8.11.20-1",
+    "version": "8.11.20-2",
     "description": "The world’s most-loved password manager.",
     "homepage": "https://1password.com/",
     "license": "Proprietary",

--- a/bucket/1password.json
+++ b/bucket/1password.json
@@ -1,14 +1,14 @@
 {
-    "version": "8.11.20",
+    "version": "8.11.20-1",
     "description": "The world’s most-loved password manager.",
     "homepage": "https://1password.com/",
     "license": "Proprietary",
-    "url": "https://c.1password.com/dist/1P/win8/1PasswordSetup-latest.exe#/dl.7z",
-    "installer": {
-        "script": [
-            "Expand-7zipArchive \"$dir\\.rdata\" -Removal",
-            "Get-ChildItem \"$dir\" | ForEach-Object { if ($_.Name -match '[^\\x00-\\x7F]') { Move-Item -Path $_.FullName -Destination $($_.FullName -replace '[^\\x00-\\x7F]','\\') } }"
-        ]
+    "architecture": {
+        "64bit": {
+            "url": "https://downloads.1password.com/win/1PasswordSetup-latest.msi",
+            "hash": "43D9EAD13972EF932444B247BA29C5859B209082B907DCA69D1572629DA31CC9",
+            "extract_dir": "ProgramFiles64Folder\\1Password\\app\\8"
+        }
     },
     "bin": "1Password.exe",
     "shortcuts": [
@@ -22,6 +22,10 @@
         "regex": "<a href=\".*?\" title=\"([\\d.]+)* - build"
     },
     "autoupdate": {
-        "url": "https://c.1password.com/dist/1P/win8/1PasswordSetup-latest.exe#/dl.7z"
+        "architecture": {
+            "64bit": {
+                "url": "https://downloads.1password.com/win/1PasswordSetup-latest.msi"
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
